### PR TITLE
Send vehicle attitude setpoints in offboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # px4-aerial-manipulation
+
+
+## Setup
+Add the repository to the ros2 workspace
+```
+git clone https://github.com/Jaeyoung-Lim/px4-manipulation.git
+```
+
+## Running
+You will make use of 3 different terminals to run the offboard demo.
+
+On the first terminal, run a SITL instance from the PX4 Autopilot firmware.
+```
+make px4_sitl gz_omnicopter
+```
+
+On the second terminal terminal, run the micro-ros-agent which will perform the mapping between Micro XRCE-DDS and uORB. So that ROS2 Nodes are able to communicate with the PX4 micrortps_client.
+```
+micro-ros-agent udp4 --port 8888
+```
+
+In order to run the offboard position control example, open a third terminal and run the the node.
+This runs two ros nodes, which publishes offboard position control setpoints and the visualizer.
+```
+ros2 launch px4_manipulation run.launch.py
+```

--- a/include/px4_manipulation/px4_manipulation.h
+++ b/include/px4_manipulation/px4_manipulation.h
@@ -48,6 +48,7 @@
 #include "std_msgs/msg/string.hpp"
 
 #include "px4_msgs/msg/offboard_control_mode.hpp"
+#include "px4_msgs/msg/vehicle_attitude_setpoint.hpp"
 #include "px4_msgs/msg/position_setpoint_triplet.hpp"
 #include "px4_msgs/msg/vehicle_status.hpp"
 #include "px4_msgs/msg/vehicle_attitude.hpp"
@@ -95,12 +96,15 @@ class Px4Manipulation : public rclcpp::Node
 
     rclcpp::TimerBase::SharedPtr statusloop_timer_;
     rclcpp::Publisher<px4_msgs::msg::OffboardControlMode>::SharedPtr offboard_mode_pub_;
+    rclcpp::Publisher<px4_msgs::msg::VehicleAttitudeSetpoint>::SharedPtr vehicle_attitude_pub_;
     rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub_;
     rclcpp::Subscription<px4_msgs::msg::VehicleAttitude>::SharedPtr vehicle_attitude_sub_;
     rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr vehicle_local_position_sub_;
   
 
     uint8_t vehicle_nav_state_;
-    Eigen::Vector4d vehicle_attitude_{Eigen::Vector4d(1.0, 0.0, 0.0, 0.0)};
+    Eigen::Quaterniond vehicle_attitude_{Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0)};
     Eigen::Vector3d vehicle_position_{Eigen::Vector3d(0.0, 0.0, 0.0)};
+    Eigen::Vector3d vehicle_velocity_{Eigen::Vector3d(0.0, 0.0, 0.0)};
+    double angle_{0.0};
 };


### PR DESCRIPTION
**Problem Description**
This commit implements a simple pid position controller and with an arbitrary attitude reference

```
ros2 launch px4_manipulation run.launch.py 
```


![rotating_omnicopter](https://github.com/Jaeyoung-Lim/px4-manipulation/assets/5248102/95ea4407-da00-4e1f-b534-b6d251db7707)

Additionally, a readme was added for instructions to run the code